### PR TITLE
added udev rule for seatrac rs232 connector

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,8 @@ if [ "$(uname -m)" == "aarch64" ]; then
       printWarning "The udev rules symlink already exists"
   else
       sudo ln -s $HOME/CoUGARs/config/local/00-teensy.rules /etc/udev/rules.d/00-teensy.rules
+      sudo ln -s $HOME/CoUGARs/config/local/99-teensy.rules /etc/udev/rules.d/99-teensy.rules
+      sudo ln -s $HOME/CoUGARs/config/local/99-seatrac.rules /etc/udev/rules.d/99-seatrac.rules
       sudo udevadm control --reload-rules
       sudo udevadm trigger
   fi

--- a/templates/local/99-seatrac.rules
+++ b/templates/local/99-seatrac.rules
@@ -1,0 +1,4 @@
+
+# Udev rule for the FTDI rs232 usb to serial connector, which connects the seatrac USBL beacon tp the raspberry pi on the cougars UV
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", manufacturerSYMLINK+="frost/rs232_connector_seatrac"
+

--- a/templates/local/99-seatrac.rules
+++ b/templates/local/99-seatrac.rules
@@ -1,4 +1,4 @@
 
 # Udev rule for the FTDI rs232 usb to serial connector, which connects the seatrac USBL beacon tp the raspberry pi on the cougars UV
-SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", manufacturerSYMLINK+="frost/rs232_connector_seatrac"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", SYMLINK+="frost/rs232_connector_seatrac"
 


### PR DESCRIPTION
### Description: 
- Added udev rule that checks for the FTDI rs232 usb to serial connector, which connects the seatrac usbl beacon to the raspberry pi on the coug.  The seatrac beacon can now be found at "/dev/frost/rs232_connector_seatrac"
- also modified modem_ros_node.cpp in the cougars-ros2 repository to use the new udev rule
- ran "ros2 run seatrac modem" in container on coug2. Worked as expected

### Checklist:
- [x] Code builds in container.
- [x] Code runs in the container and on a vehicle.
- [ ] I have updated the documentation as needed.
- [x] I have performed a self-review of my code.
- [x] I have resolved any merge conflicts before submission.

### Tests:
- [x] Bench Test
- [ ] Bucket Test / Tank Test
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
none

### Additional work possible:
none
