### PR TITLE
Moos extend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cougars-gpio
 cougars-docs
 cougars-base-station
 cougars_base_station
+moos-ivp-extend
+cougars_sim_converters

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,6 +146,7 @@ RUN ./build-ivp.sh
 
 # Build moos-ivp-extend stuff
 WORKDIR /home/${LABNAME}/moos-ivp-extend
+RUN ./clean.sh
 RUN ./build.sh
 
 WORKDIR /home/${LABNAME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,7 +143,14 @@ RUN svn co https://oceanai.mit.edu/svn/moos-ivp-aro/trunk moos-ivp
 WORKDIR /home/${LABNAME}/moos-ivp
 RUN ./build-moos.sh
 RUN ./build-ivp.sh
+
+# Build moos-ivp-extend stuff
+WORKDIR /home/${LABNAME}/moos-ivp-extend
+RUN ./build.sh
+
 WORKDIR /home/${LABNAME}
+
+
 
 # Install development dependencies (rqt, plotjuggler, documentation, etc.)
 USER root

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -23,6 +23,7 @@ services:
       - ../cougars-teensy:/home/frostlab/teensy_ws
       - ../cougars-gpio:/home/frostlab/gpio
       - ../cougars-docs:/home/frostlab/docs
+      - ../moos-ivp-extend:/home/frostlab/moos-ivp-extend
       - /dev:/dev:rw
       - /etc/localtime:/etc/localtime:ro # Syncs the container's time with the host
       - /tmp/.X11-unix:/tmp/.X11-unix # Required for GUI applications

--- a/docker/docker-compose-rt.yaml
+++ b/docker/docker-compose-rt.yaml
@@ -17,6 +17,7 @@ services:
       - ../cougars-ros2:/home/frostlab/ros2_ws
       - ../cougars-teensy:/home/frostlab/teensy_ws
       - ../cougars-gpio:/home/frostlab/gpio
+      - ../moos-ivp-extend:/home/frostlab/moos-ivp-extend
       - /etc/localtime:/etc/localtime:ro # Syncs the container's time with the host
       - /dev:/dev:rw
       - /run/udev:/run/udev:ro

--- a/setup.sh
+++ b/setup.sh
@@ -132,8 +132,8 @@ else
   fi
 
   # Copy repos from GitHub
-  git clone https://github.com/BYU-FRoSt-Lab/cougars-docs.git
-  git clone https://github.com/BYU-FRoSt-Lab/cougars-base-station.git
+  git clone git@github.com:BYU-FRoSt-Lab/cougars-docs.git
+  git clone git@github.com:BYU-FRoSt-Lab/cougars-base-station.git
 
   ### END DEV-SPECIFIC SETUP ###
 
@@ -143,8 +143,9 @@ fi
 unset LC_ALL
 
 # Copy repos from GitHub
-git clone https://github.com/BYU-FRoSt-Lab/cougars-ros2.git
-git clone https://github.com/BYU-FRoSt-Lab/cougars-teensy.git
-git clone https://github.com/BYU-FRoSt-Lab/cougars-gpio.git
+git clone git@github.com:BYU-FRoSt-Lab/cougars-ros2.git
+git clone git@github.com:BYU-FRoSt-Lab/cougars-teensy.git
+git clone git@github.com:BYU-FRoSt-Lab/cougars-gpio.git
+git clone git@github.com:BYU-FRoSt-Lab/moos-ivp-extend.git
 
 printInfo "Make sure to update the vehicle-specific configuration files in "config" now"


### PR DESCRIPTION
Adds the moos-ivp-extend directory to the repos that we are using. Builds moos-ivp-extend in the dockerfile. Changed git clones to ssh instead of https